### PR TITLE
fix: replace .max()[0] with .max().iloc[0] for pandas v2.x compatibility

### DIFF
--- a/src/models/Autoencoder/Type_1/table_generator.py
+++ b/src/models/Autoencoder/Type_1/table_generator.py
@@ -77,7 +77,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [max(t_t)+1]
      ###### Normalize the input as the autoencoder only uses the input
     # MMScaler = MinMaxScaler()

--- a/src/models/Autoencoder/Type_LB/table_generator.py
+++ b/src/models/Autoencoder/Type_LB/table_generator.py
@@ -82,7 +82,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [max(t_t)+1]
      ###### Normalize the input as the autoencoder only uses the input
     # MMScaler = MinMaxScaler()

--- a/src/models/Bayes/Type_1/table_generator.py
+++ b/src/models/Bayes/Type_1/table_generator.py
@@ -75,7 +75,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/Bayes/Type_2/table_generator.py
+++ b/src/models/Bayes/Type_2/table_generator.py
@@ -95,7 +95,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/Bayes/Type_3/table_generator.py
+++ b/src/models/Bayes/Type_3/table_generator.py
@@ -75,7 +75,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/Bayes/Type_LB/table_generator.py
+++ b/src/models/Bayes/Type_LB/table_generator.py
@@ -75,7 +75,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/Bayes/Type_LB_Bernoulli/table_generator.py
+++ b/src/models/Bayes/Type_LB_Bernoulli/table_generator.py
@@ -85,7 +85,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/DT/Type_1/table_generator.py
+++ b/src/models/DT/Type_1/table_generator.py
@@ -298,7 +298,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/DT/Type_1_xsa/table_generator.py
+++ b/src/models/DT/Type_1_xsa/table_generator.py
@@ -296,7 +296,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/DT/Type_2/table_generator.py
+++ b/src/models/DT/Type_2/table_generator.py
@@ -294,7 +294,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/DT/Type_3/table_generator.py
+++ b/src/models/DT/Type_3/table_generator.py
@@ -305,7 +305,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/DT/Type_4/table_generator.py
+++ b/src/models/DT/Type_4/table_generator.py
@@ -306,7 +306,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/DT/Type_5/table_generator.py
+++ b/src/models/DT/Type_5/table_generator.py
@@ -301,7 +301,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/DT/Type_DM/table_generator.py
+++ b/src/models/DT/Type_DM/table_generator.py
@@ -259,7 +259,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/DT/Type_EB/table_generator.py
+++ b/src/models/DT/Type_EB/table_generator.py
@@ -305,7 +305,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/DT/Type_depth_based_bmv2_only/table_generator.py
+++ b/src/models/DT/Type_depth_based_bmv2_only/table_generator.py
@@ -254,7 +254,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/IF/Type_1/table_generator.py
+++ b/src/models/IF/Type_1/table_generator.py
@@ -358,7 +358,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/IF/Type_2/table_generator.py
+++ b/src/models/IF/Type_2/table_generator.py
@@ -316,7 +316,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/IF/Type_EB/table_generator.py
+++ b/src/models/IF/Type_EB/table_generator.py
@@ -359,7 +359,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/IF/Type_Simplified_EB/table_generator.py
+++ b/src/models/IF/Type_Simplified_EB/table_generator.py
@@ -319,7 +319,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/KM/Type_1/table_generator.py
+++ b/src/models/KM/Type_1/table_generator.py
@@ -54,7 +54,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t) + 1]
     # print(feature_max)
 

--- a/src/models/KM/Type_1/table_generator.py
+++ b/src/models/KM/Type_1/table_generator.py
@@ -60,7 +60,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_min = []
     for i in feature_names:
-        t_t = [test_X[[i]].min()[0], train_X[[i]].min()[0]]
+        t_t = [test_X[[i]].min().iloc[0], train_X[[i]].min().iloc[0]]
         feature_min += [np.min(t_t) ]
     # print(feature_min)
 

--- a/src/models/KM/Type_EB/table_generator.py
+++ b/src/models/KM/Type_EB/table_generator.py
@@ -204,7 +204,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t) + 1]
     # print(feature_max)
 

--- a/src/models/KM/Type_EB/table_generator.py
+++ b/src/models/KM/Type_EB/table_generator.py
@@ -210,7 +210,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_min = []
     for i in feature_names:
-        t_t = [test_X[[i]].min()[0], train_X[[i]].min()[0]]
+        t_t = [test_X[[i]].min().iloc[0], train_X[[i]].min().iloc[0]]
         feature_min += [np.min(t_t) ]
     # print(feature_min)
 

--- a/src/models/KM/Type_LB/table_generator.py
+++ b/src/models/KM/Type_LB/table_generator.py
@@ -54,7 +54,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t) + 1]
     # print(feature_max)
 

--- a/src/models/KM/Type_LB/table_generator.py
+++ b/src/models/KM/Type_LB/table_generator.py
@@ -60,7 +60,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_min = []
     for i in feature_names:
-        t_t = [test_X[[i]].min()[0], train_X[[i]].min()[0]]
+        t_t = [test_X[[i]].min().iloc[0], train_X[[i]].min().iloc[0]]
         feature_min += [np.min(t_t) ]
     # print(feature_min)
 

--- a/src/models/KM/Type_clustreams/table_generator.py
+++ b/src/models/KM/Type_clustreams/table_generator.py
@@ -204,7 +204,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t) + 1]
     # print(feature_max)
 

--- a/src/models/KM/Type_clustreams/table_generator.py
+++ b/src/models/KM/Type_clustreams/table_generator.py
@@ -210,7 +210,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_min = []
     for i in feature_names:
-        t_t = [test_X[[i]].min()[0], train_X[[i]].min()[0]]
+        t_t = [test_X[[i]].min().iloc[0], train_X[[i]].min().iloc[0]]
         feature_min += [np.min(t_t) ]
     # print(feature_min)
 

--- a/src/models/KNN/Type_1/table_generator.py
+++ b/src/models/KNN/Type_1/table_generator.py
@@ -199,7 +199,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t) + 1]
     # print(feature_max)
 

--- a/src/models/KNN/Type_1/table_generator.py
+++ b/src/models/KNN/Type_1/table_generator.py
@@ -205,7 +205,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_min = []
     for i in feature_names:
-        t_t = [test_X[[i]].min()[0], train_X[[i]].min()[0]]
+        t_t = [test_X[[i]].min().iloc[0], train_X[[i]].min().iloc[0]]
         feature_min += [np.min(t_t) ]
     # print(feature_min)
 

--- a/src/models/KNN/Type_EB/table_generator.py
+++ b/src/models/KNN/Type_EB/table_generator.py
@@ -200,7 +200,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
         feature_names += ["f" + str(i)]
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t) + 1]
     # print(feature_max)
 

--- a/src/models/KNN/Type_EB/table_generator.py
+++ b/src/models/KNN/Type_EB/table_generator.py
@@ -206,7 +206,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_min = []
     for i in feature_names:
-        t_t = [test_X[[i]].min()[0], train_X[[i]].min()[0]]
+        t_t = [test_X[[i]].min().iloc[0], train_X[[i]].min().iloc[0]]
         feature_min += [np.min(t_t) ]
     # print(feature_min)
 

--- a/src/models/NN/Type_1/table_generator.py
+++ b/src/models/NN/Type_1/table_generator.py
@@ -95,7 +95,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     width = []

--- a/src/models/NN/Type_2/table_generator.py
+++ b/src/models/NN/Type_2/table_generator.py
@@ -142,7 +142,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     width = []

--- a/src/models/NN/Type_DM/table_generator.py
+++ b/src/models/NN/Type_DM/table_generator.py
@@ -95,7 +95,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     width = []

--- a/src/models/PCA/Type_1/table_generator.py
+++ b/src/models/PCA/Type_1/table_generator.py
@@ -46,7 +46,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/PCA/Type_LB/table_generator.py
+++ b/src/models/PCA/Type_LB/table_generator.py
@@ -46,7 +46,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_1/table_generator.py
+++ b/src/models/RF/Type_1/table_generator.py
@@ -302,7 +302,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # Random Forest

--- a/src/models/RF/Type_1_xsa/table_generator.py
+++ b/src/models/RF/Type_1_xsa/table_generator.py
@@ -299,7 +299,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # Random Forest

--- a/src/models/RF/Type_2/table_generator.py
+++ b/src/models/RF/Type_2/table_generator.py
@@ -298,7 +298,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # Random Forest

--- a/src/models/RF/Type_3/table_generator.py
+++ b/src/models/RF/Type_3/table_generator.py
@@ -308,7 +308,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_4/table_generator.py
+++ b/src/models/RF/Type_4/table_generator.py
@@ -308,7 +308,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_5/table_generator.py
+++ b/src/models/RF/Type_5/table_generator.py
@@ -304,7 +304,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_DM/table_generator.py
+++ b/src/models/RF/Type_DM/table_generator.py
@@ -259,7 +259,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/RF/Type_DM_bmv2_only/table_generator.py
+++ b/src/models/RF/Type_DM_bmv2_only/table_generator.py
@@ -256,7 +256,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_EB/table_generator.py
+++ b/src/models/RF/Type_EB/table_generator.py
@@ -309,7 +309,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_EB_auto/table_generator.py
+++ b/src/models/RF/Type_EB_auto/table_generator.py
@@ -325,7 +325,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/RF/Type_depth_based/table_generator.py
+++ b/src/models/RF/Type_depth_based/table_generator.py
@@ -259,7 +259,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
 

--- a/src/models/RF/Type_depth_based_bmv2_only/table_generator.py
+++ b/src/models/RF/Type_depth_based_bmv2_only/table_generator.py
@@ -258,7 +258,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/SVM/Type_1/table_generator.py
+++ b/src/models/SVM/Type_1/table_generator.py
@@ -89,7 +89,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
     
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [max(t_t)]
 
     # =================== train model timer ===================

--- a/src/models/SVM/Type_LB/table_generator.py
+++ b/src/models/SVM/Type_LB/table_generator.py
@@ -89,7 +89,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
     
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [max(t_t)]
 
     # =================== train model timer ===================

--- a/src/models/XGB/Type_1/table_generator.py
+++ b/src/models/XGB/Type_1/table_generator.py
@@ -234,7 +234,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/XGB/Type_2/table_generator.py
+++ b/src/models/XGB/Type_2/table_generator.py
@@ -235,7 +235,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/XGB/Type_2_xsa/table_generator.py
+++ b/src/models/XGB/Type_2_xsa/table_generator.py
@@ -237,7 +237,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/XGB/Type_3/table_generator.py
+++ b/src/models/XGB/Type_3/table_generator.py
@@ -238,7 +238,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [np.max(t_t)+1]
 
     # =================== train model timer ===================

--- a/src/models/XGB/Type_EB/table_generator.py
+++ b/src/models/XGB/Type_EB/table_generator.py
@@ -236,7 +236,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================

--- a/src/models/XGB/Type_EB_auto/table_generator.py
+++ b/src/models/XGB/Type_EB_auto/table_generator.py
@@ -258,7 +258,7 @@ def run_model(train_X, train_y, test_X, test_y, used_features):
 
     feature_max = []
     for i in feature_names:
-        t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
+        t_t = [test_X[[i]].max().iloc[0], train_X[[i]].max().iloc[0]]
         feature_max += [int(np.max(t_t)+1)]
 
     # =================== train model timer ===================


### PR DESCRIPTION
## Summary

Fix a `KeyError: 0` crash that occurs across all ML modules when running Planter with pandas >= 2.0.

## Root Cause
`packages.txt` specifies `pandas==1.1.3`, where `.max()[0]` happens to work. However, pandas v2.0 removed support for positional integer indexing on `Series`, so the following pattern raises `KeyError: 0` on modern environments (e.g., Ubuntu 24.04 with Python 3.12):
```python
t_t = [test_X[[i]].max()[0], train_X[[i]].max()[0]]
```

`.max()` returns a `Series` indexed by column name, not by position.
Using `[0]` attempts to look up a column named `0`, which does not exist.

## Fix
Replace `.max()[0]` with `.max().iloc[0]`, which uses explicit positional indexing and is compatible with both pandas v1. x and v2. x.

## Affected Files
51 `table_generator.py` files across all ML modules: RF, DT, XGB, SVM, KNN, KM, NN, Bayes, IF, PCA, Autoencoder

## Tested
- Python 3.12, pandas 2.x, Ubuntu 24.04 ARM
- RF/Type_EB on Iris dataset: accuracy 0.9556 ✓ (Matrix 1–3 all passing)