### PR TITLE
fix: replace plt.style.use('seaborn') with 'seaborn-v0_8' for matplotlib 3.6+ compatibility

### DIFF
--- a/src/models/DT/Type_1/table_generator.py
+++ b/src/models/DT/Type_1/table_generator.py
@@ -17,7 +17,7 @@ from pandas import plotting
 import copy
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/DT/Type_1_xsa/table_generator.py
+++ b/src/models/DT/Type_1_xsa/table_generator.py
@@ -17,7 +17,7 @@ from pandas import plotting
 import copy
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/DT/Type_2/table_generator.py
+++ b/src/models/DT/Type_2/table_generator.py
@@ -17,7 +17,7 @@ from pandas import plotting
 import copy
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/DT/Type_3/table_generator.py
+++ b/src/models/DT/Type_3/table_generator.py
@@ -18,7 +18,7 @@ import copy
 import time
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/DT/Type_5/table_generator.py
+++ b/src/models/DT/Type_5/table_generator.py
@@ -18,7 +18,7 @@ import copy
 import time
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/DT/Type_EB/table_generator.py
+++ b/src/models/DT/Type_EB/table_generator.py
@@ -18,7 +18,7 @@ import copy
 import time
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/NN/Type_1/table_generator.py
+++ b/src/models/NN/Type_1/table_generator.py
@@ -23,7 +23,7 @@ import time
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/NN/Type_2/table_generator.py
+++ b/src/models/NN/Type_2/table_generator.py
@@ -21,7 +21,7 @@ import os
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/NN/Type_DM/table_generator.py
+++ b/src/models/NN/Type_DM/table_generator.py
@@ -23,7 +23,7 @@ import time
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/XGB/Type_1/table_generator.py
+++ b/src/models/XGB/Type_1/table_generator.py
@@ -19,7 +19,7 @@ import os
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/XGB/Type_2/table_generator.py
+++ b/src/models/XGB/Type_2/table_generator.py
@@ -19,7 +19,7 @@ import os
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/XGB/Type_2_xsa/table_generator.py
+++ b/src/models/XGB/Type_2_xsa/table_generator.py
@@ -19,7 +19,7 @@ import os
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/XGB/Type_3/table_generator.py
+++ b/src/models/XGB/Type_3/table_generator.py
@@ -19,7 +19,7 @@ import os
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/XGB/Type_EB/table_generator.py
+++ b/src/models/XGB/Type_EB/table_generator.py
@@ -19,7 +19,7 @@ import os
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 
 import seaborn as sns
 sns.set_style("whitegrid")

--- a/src/models/XGB/Type_EB_auto/table_generator.py
+++ b/src/models/XGB/Type_EB_auto/table_generator.py
@@ -24,7 +24,7 @@ import json
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('seaborn')
+plt.style.use('seaborn-v0_8')
 import seaborn as sns
 sns.set_style("whitegrid")
 


### PR DESCRIPTION
## Summary

Fix a `matplotlib` deprecation/breakage across 15 `table_generator.py` files in the DT, NN, and XGB modules.

## Root Cause

Matplotlib 3.6 deprecated the `'seaborn'` style name, and matplotlib 3.8+ removed it entirely. On modern environments (e.g., Ubuntu 24.04 with Python 3.12 and matplotlib 3.10), `plt.style.use('seaborn')` raises:

```
OSError: 'seaborn' not found in the style library
```

## Fix

Replace `plt.style.use('seaborn')` with `plt.style.use('seaborn-v0_8')`, which is the renamed style and is compatible with both older and current matplotlib versions.

## Affected Files

15 `table_generator.py` files across DT (6), NN (3), and XGB (6) modules.

## Tested

- Python 3.12, matplotlib 3.10.8, Ubuntu 24.04 ARM
- DT/Type_4 end-to-end through BMv2 deployment on Iris dataset

Related: #8
See also: #7 (pandas fix for the same outdated dependency issue)